### PR TITLE
refactor: make auth rate limiter check-only

### DIFF
--- a/apps/backend/src/lib/auth-rate-limiter.ts
+++ b/apps/backend/src/lib/auth-rate-limiter.ts
@@ -21,28 +21,14 @@ export class AuthRateLimiter {
     const record = this.attempts.get(identifier);
 
     if (!record) {
-      this.attempts.set(identifier, {
-        count: 1,
-        resetTime: now + this.windowMs,
-      });
       return false;
     }
 
     if (now > record.resetTime) {
-      // Reset window
-      this.attempts.set(identifier, {
-        count: 1,
-        resetTime: now + this.windowMs,
-      });
       return false;
     }
 
-    if (record.count >= this.maxAttempts) {
-      return true;
-    }
-
-    record.count++;
-    return false;
+    return record.count >= this.maxAttempts;
   }
 
   recordFailedAttempt(identifier: string): void {


### PR DESCRIPTION
## Summary
- update the auth rate limiter so `isRateLimited` only inspects the stored attempt counts
- verified the authentication middleware records failed attempts before checking the limiter

## Testing
- pnpm --filter backend lint *(fails: pre-existing eslint warnings throughout the backend package)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c1cd2a948327a16035d915dfa38f

## Zusammenfassung von Sourcery

Verbesserungen:
- Refaktorisierung von AuthRateLimiter.isRateLimited, um nur gespeicherte Versuchsdatensätze zu prüfen, ohne den Zustand zu verändern oder zurückzusetzen

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refactor AuthRateLimiter.isRateLimited to only inspect stored attempt records without mutating or resetting state

</details>