### PR TITLE
feat: configure frontend session validation base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ For more details and alternative approaches, see [issue #76](https://github.com/
 - 🏢 **Multi-tenancy**: Designed for organizations to deploy on their own machines. Supports both private and public access scopes. Users can create MCPs, namespaces, endpoints, and API keys for themselves or for everyone. Public API keys cannot access private MetaMCPs.
 - ⚙️ **Separate Registration Controls**: Administrators can independently control UI registration and SSO/OAuth registration through the settings page, allowing for flexible enterprise deployment scenarios.
 
+### Frontend session validation base URL
+
+Set the optional `AUTH_SESSION_BASE_URL` environment variable when the frontend middleware must reach the Better Auth session endpoint via an internal network address (for example, when Docker networking prevents access to `APP_URL`). When the variable is not provided, the middleware derives the base URL from the incoming request origin and forwarded headers so authentication succeeds behind reverse proxies and other non-local deployments.
+
 ## 🔗 OpenID Connect (OIDC) Provider Support
 
 MetaMCP supports **OpenID Connect authentication** for enterprise SSO integration. This allows organizations to use their existing identity providers (Auth0, Keycloak, Azure AD, etc.) for authentication.

--- a/example.env
+++ b/example.env
@@ -17,6 +17,10 @@ NEXT_PUBLIC_APP_URL=http://localhost:23456
 
 # Auth configuration
 BETTER_AUTH_SECRET=your-super-secret-key-change-this-in-production
+# AUTH_SESSION_BASE_URL overrides the URL used by the frontend middleware
+# when validating sessions. Set this if the app cannot reach APP_URL
+# directly (for example, inside Docker networking).
+# AUTH_SESSION_BASE_URL=http://127.0.0.1:32009
 
 # OIDC Provider Configuration (Optional)
 # Uncomment and configure these variables to enable OpenID Connect authentication


### PR DESCRIPTION
## Summary
- allow overriding the frontend auth session check base URL through an environment variable and fall back to the request origin for non-local deployments
- document the new `AUTH_SESSION_BASE_URL` option in the README and example environment file

## Testing
- pnpm lint *(fails: existing backend lint warnings unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c1e36b8c8327a1a8347b69b982b0

## Zusammenfassung von Sourcery

Ermöglicht die Anpassung der Basis-URL für den Frontend-Authentifizierungssitzungs-Endpunkt über eine Umgebungsvariable und leitet einen Fallback vom Anforderungsursprung und den weitergeleiteten Headern für nicht-lokale Bereitstellungen ab, sowie dokumentiert die neue Option.

Neue Funktionen:
- Ermöglicht das Überschreiben der Basis-URL für den Frontend-Authentifizierungssitzungs-Endpunkt mit der Umgebungsvariable `AUTH_SESSION_BASE_URL`
- Standardmäßig wird die Sitzungs-Basis-URL vom eingehenden Anforderungsursprung und den weitergeleiteten Headern abgeleitet, wenn keine Überschreibung bereitgestellt wird

Dokumentation:
- Dokumentiert die Option `AUTH_SESSION_BASE_URL` in der README
- Fügt das `AUTH_SESSION_BASE_URL`-Beispiel zur Datei `example.env` hinzu

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow customizing the frontend authentication session endpoint base URL via an environment variable and derive a fallback from the request origin and forwarded headers for non-local deployments, and document the new option.

New Features:
- Allow overriding the frontend authentication session endpoint base URL with the AUTH_SESSION_BASE_URL environment variable
- Default to deriving the session base URL from the incoming request origin and forwarded headers when no override is provided

Documentation:
- Document the AUTH_SESSION_BASE_URL option in the README
- Add the AUTH_SESSION_BASE_URL example to the example.env file

</details>