### PR TITLE
Configure tRPC CORS origins via environment or config file

### DIFF
--- a/apps/backend/src/routers/trpc.ts
+++ b/apps/backend/src/routers/trpc.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+
 import { createAppRouter } from "@repo/trpc";
 import * as trpcExpress from "@trpc/server/adapters/express";
 import cors from "cors";
@@ -13,6 +15,94 @@ import { mcpServersImplementations } from "../trpc/mcp-servers.impl";
 import { namespacesImplementations } from "../trpc/namespaces.impl";
 import { oauthImplementations } from "../trpc/oauth.impl";
 import { toolsImplementations } from "../trpc/tools.impl";
+
+const DEFAULT_TRPC_ALLOWED_ORIGINS = [
+  "http://192.168.2.222:23456",
+  "http://localhost:23456",
+  "http://127.0.0.1:23456",
+];
+
+const splitOrigins = (value: string | undefined): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(/[\s,]+/)
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+};
+
+type ResolveOriginsOptions = {
+  env?: NodeJS.ProcessEnv;
+  readFile?: (filePath: string) => string;
+  fileExists?: (filePath: string) => boolean;
+};
+
+export const resolveTrpcAllowedOrigins = (
+  options: ResolveOriginsOptions = {},
+): string[] => {
+  const env = options.env ?? process.env;
+  const readFile =
+    options.readFile ?? ((filePath: string) => readFileSync(filePath, "utf8"));
+  const fileExists = options.fileExists ?? existsSync;
+
+  const configuredOrigins = new Set<string>();
+
+  const envOrigins = splitOrigins(
+    env.TRPC_ALLOWED_ORIGINS ?? env.CORS_ALLOWED_ORIGINS,
+  );
+  for (const origin of envOrigins) {
+    configuredOrigins.add(origin);
+  }
+
+  const filePath = env.TRPC_ALLOWED_ORIGINS_FILE;
+  if (filePath && fileExists(filePath)) {
+    try {
+      const fileContents = readFile(filePath).trim();
+      if (fileContents) {
+        try {
+          const parsed = JSON.parse(fileContents);
+          if (Array.isArray(parsed)) {
+            for (const entry of parsed) {
+              if (typeof entry === "string") {
+                const trimmed = entry.trim();
+                if (trimmed) {
+                  configuredOrigins.add(trimmed);
+                }
+              }
+            }
+          } else if (typeof parsed === "string") {
+            for (const origin of splitOrigins(parsed)) {
+              configuredOrigins.add(origin);
+            }
+          }
+        } catch {
+          for (const origin of splitOrigins(fileContents)) {
+            configuredOrigins.add(origin);
+          }
+        }
+      }
+    } catch {
+      // Ignore file read errors and fall back to other configuration sources.
+    }
+  }
+
+  const appUrl = env.APP_URL?.trim();
+  if (appUrl) {
+    configuredOrigins.add(appUrl);
+  }
+
+  if (!configuredOrigins.size) {
+    for (const origin of DEFAULT_TRPC_ALLOWED_ORIGINS) {
+      configuredOrigins.add(origin);
+    }
+  }
+
+  return Array.from(configuredOrigins);
+};
+
+const allowedOrigins = resolveTrpcAllowedOrigins();
 
 // Create the app router with implementations
 const appRouter = createAppRouter({
@@ -38,11 +128,7 @@ const trpcRouter = express.Router();
 trpcRouter.use(helmet());
 trpcRouter.use(
   cors({
-    origin: [
-      "http://192.168.2.222:23456",
-      "http://localhost:23456",
-      "http://127.0.0.1:23456",
-    ],
+    origin: allowedOrigins,
     credentials: true,
   }),
 );

--- a/example.env
+++ b/example.env
@@ -15,6 +15,12 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}
 APP_URL=http://localhost:23456
 NEXT_PUBLIC_APP_URL=http://localhost:23456
 
+# CORS configuration for tRPC endpoints
+# Accepts a comma or whitespace separated list of allowed origins
+# TRPC_ALLOWED_ORIGINS=http://app.example.com https://admin.example.com
+# Optionally point to a file containing a JSON array or newline separated origins
+# TRPC_ALLOWED_ORIGINS_FILE=./config/trpc-allowed-origins.txt
+
 # Auth configuration
 BETTER_AUTH_SECRET=your-super-secret-key-change-this-in-production
 


### PR DESCRIPTION
## Summary
- load the tRPC router CORS origin whitelist from environment variables or an external file with sensible defaults
- document the new configuration options in the sample environment file

## Testing
- pnpm --filter backend lint *(fails: existing warnings across unrelated files)*
- pnpm --filter backend exec tsx /tmp/verify-trpc-cors.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8c1eab46883278716a197b922e00f

## Zusammenfassung von Sourcery

Ermöglicht die dynamische Konfiguration von tRPC CORS-Ursprüngen über Umgebungsvariablen oder eine externe Datei mit sinnvollen Standardeinstellungen

Verbesserungen:
- Einführung des `resolveTrpcAllowedOrigins`-Hilfsprogramms, um erlaubte Ursprünge aus den Umgebungsvariablen `TRPC_ALLOWED_ORIGINS` oder `CORS_ALLOWED_ORIGINS`, `TRPC_ALLOWED_ORIGINS_FILE` und `APP_URL` zu parsen
- Ersetzt die fest codierte CORS-Ursprungsliste im tRPC-Router durch die dynamisch aufgelösten `allowedOrigins`

Dokumentation:
- Dokumentiert die neuen Konfigurationsoptionen `TRPC_ALLOWED_ORIGINS`, `CORS_ALLOWED_ORIGINS`, `TRPC_ALLOWED_ORIGINS_FILE` und `APP_URL` in `example.env`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable dynamic configuration of tRPC CORS origins via environment variables or an external file with sensible defaults

Enhancements:
- Introduce resolveTrpcAllowedOrigins utility to parse allowed origins from TRPC_ALLOWED_ORIGINS or CORS_ALLOWED_ORIGINS env vars, TRPC_ALLOWED_ORIGINS_FILE, and APP_URL
- Replace hardcoded CORS origin list in the tRPC router with the dynamically resolved allowedOrigins

Documentation:
- Document new TRPC_ALLOWED_ORIGINS, CORS_ALLOWED_ORIGINS, TRPC_ALLOWED_ORIGINS_FILE, and APP_URL configuration options in example.env

</details>