### PR TITLE
feat: share session transport store

### DIFF
--- a/apps/backend/src/lib/session-store.ts
+++ b/apps/backend/src/lib/session-store.ts
@@ -1,0 +1,23 @@
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+const transports = new Map<string, Transport>();
+
+export function setTransport(key: string, transport: Transport): void {
+  transports.set(key, transport);
+}
+
+export function getTransport<T extends Transport = Transport>(
+  key: string,
+): T | undefined {
+  return transports.get(key) as T | undefined;
+}
+
+export function deleteTransport<T extends Transport = Transport>(
+  key: string,
+): T | undefined {
+  const transport = transports.get(key) as T | undefined;
+  if (transport) {
+    transports.delete(key);
+  }
+  return transport;
+}

--- a/apps/backend/src/routers/public-metamcp/sse.ts
+++ b/apps/backend/src/routers/public-metamcp/sse.ts
@@ -1,18 +1,17 @@
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import express from "express";
 
-import {
-  ApiKeyAuthenticatedRequest,
-  authenticateApiKey,
-} from "@/middleware/api-key-oauth.middleware";
+import { ApiKeyAuthenticatedRequest } from "@/middleware/api-key-oauth.middleware";
 import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
 
 import { metaMcpServerPool } from "../../lib/metamcp/metamcp-server-pool";
+import {
+  deleteTransport,
+  getTransport,
+  setTransport,
+} from "../../lib/session-store";
 
 const sseRouter = express.Router();
-
-const webAppTransports: Map<string, Transport> = new Map<string, Transport>(); // Web app transports by sessionId
 
 // Cleanup function for a specific session
 const cleanupSession = async (sessionId: string) => {
@@ -20,11 +19,10 @@ const cleanupSession = async (sessionId: string) => {
 
   try {
     // Clean up transport
-    const transport = webAppTransports.get(sessionId);
+    const transport = deleteTransport<SSEServerTransport>(sessionId);
     if (transport) {
       console.log(`Closing transport for session ${sessionId}`);
       await transport.close();
-      webAppTransports.delete(sessionId);
       console.log(`Transport cleaned up for session ${sessionId}`);
     } else {
       console.log(`No transport found for session ${sessionId}`);
@@ -37,8 +35,8 @@ const cleanupSession = async (sessionId: string) => {
   } catch (error) {
     console.error(`Error during cleanup of session ${sessionId}:`, error);
     // Even if cleanup fails, remove the transport from our map to prevent memory leaks
-    if (webAppTransports.has(sessionId)) {
-      webAppTransports.delete(sessionId);
+    const orphanedTransport = deleteTransport<SSEServerTransport>(sessionId);
+    if (orphanedTransport) {
       console.log(
         `Removed orphaned transport for session ${sessionId} due to cleanup error`,
       );
@@ -47,84 +45,74 @@ const cleanupSession = async (sessionId: string) => {
   }
 };
 
-sseRouter.get(
-  "/:endpoint_name/sse",
-  lookupEndpoint,
-  async (req, res) => {
-    const authReq = req as ApiKeyAuthenticatedRequest;
-    const { namespaceUuid, endpointName } = authReq;
+sseRouter.get("/:endpoint_name/sse", lookupEndpoint, async (req, res) => {
+  const authReq = req as ApiKeyAuthenticatedRequest;
+  const { namespaceUuid, endpointName } = authReq;
 
-    try {
-      console.log(
-        `New public endpoint SSE connection request for ${endpointName} -> namespace ${namespaceUuid}`,
-      );
+  try {
+    console.log(
+      `New public endpoint SSE connection request for ${endpointName} -> namespace ${namespaceUuid}`,
+    );
 
-      const webAppTransport = new SSEServerTransport(
-        `/metamcp/${endpointName}/message`,
-        res,
-      );
-      console.log("Created public endpoint SSE transport");
+    const webAppTransport = new SSEServerTransport(
+      `/metamcp/${endpointName}/message`,
+      res,
+    );
+    console.log("Created public endpoint SSE transport");
 
-      const sessionId = webAppTransport.sessionId;
+    const sessionId = webAppTransport.sessionId;
 
-      // Get or create MetaMCP server instance from the pool
-      const mcpServerInstance = await metaMcpServerPool.getServer(
-        sessionId,
-        namespaceUuid,
-      );
-      if (!mcpServerInstance) {
-        throw new Error("Failed to get MetaMCP server instance from pool");
-      }
-
-      console.log(
-        `Using MetaMCP server instance for public endpoint session ${sessionId}`,
-      );
-
-      webAppTransports.set(sessionId, webAppTransport);
-
-      // Handle cleanup when connection closes
-      res.on("close", async () => {
-        console.log(
-          `Public endpoint SSE connection closed for session ${sessionId}`,
-        );
-        await cleanupSession(sessionId);
-      });
-
-      await mcpServerInstance.server.connect(webAppTransport);
-    } catch (error) {
-      console.error("Error in public endpoint /sse route:", error);
-      res.status(500).json(error);
+    // Get or create MetaMCP server instance from the pool
+    const mcpServerInstance = await metaMcpServerPool.getServer(
+      sessionId,
+      namespaceUuid,
+    );
+    if (!mcpServerInstance) {
+      throw new Error("Failed to get MetaMCP server instance from pool");
     }
-  },
-);
 
-sseRouter.post(
-  "/:endpoint_name/message",
-  lookupEndpoint,
-  async (req, res) => {
-    // const authReq = req as ApiKeyAuthenticatedRequest;
-    // const { namespaceUuid, endpointName } = authReq;
+    console.log(
+      `Using MetaMCP server instance for public endpoint session ${sessionId}`,
+    );
 
-    try {
-      const sessionId = req.query.sessionId;
-      // console.log(
-      //   `Received POST message for public endpoint ${endpointName} -> namespace ${namespaceUuid} sessionId ${sessionId}`,
-      // );
+    setTransport(sessionId, webAppTransport);
 
-      const transport = webAppTransports.get(
-        sessionId as string,
-      ) as SSEServerTransport;
-      if (!transport) {
-        res.status(404).end("Session not found");
-        return;
-      }
-      await transport.handlePostMessage(req, res);
-    } catch (error) {
-      console.error("Error in public endpoint /message route:", error);
-      res.status(500).json(error);
+    // Handle cleanup when connection closes
+    res.on("close", async () => {
+      console.log(
+        `Public endpoint SSE connection closed for session ${sessionId}`,
+      );
+      await cleanupSession(sessionId);
+    });
+
+    await mcpServerInstance.server.connect(webAppTransport);
+  } catch (error) {
+    console.error("Error in public endpoint /sse route:", error);
+    res.status(500).json(error);
+  }
+});
+
+sseRouter.post("/:endpoint_name/message", lookupEndpoint, async (req, res) => {
+  // const authReq = req as ApiKeyAuthenticatedRequest;
+  // const { namespaceUuid, endpointName } = authReq;
+
+  try {
+    const sessionId = req.query.sessionId;
+    // console.log(
+    //   `Received POST message for public endpoint ${endpointName} -> namespace ${namespaceUuid} sessionId ${sessionId}`,
+    // );
+
+    const transport = getTransport<SSEServerTransport>(sessionId as string);
+    if (!transport) {
+      res.status(404).end("Session not found");
+      return;
     }
-  },
-);
+    await transport.handlePostMessage(req, res);
+  } catch (error) {
+    console.error("Error in public endpoint /message route:", error);
+    res.status(500).json(error);
+  }
+});
 
 // Test route to verify router is working
 sseRouter.get("/test", (req, res) => {


### PR DESCRIPTION
## Summary
- add a shared session transport store with helpers to set, get, and delete transports
- update MetaMCP, STDIO proxy, and public MetaMCP routers to use the shared store
- hook session close events to remove transports from the store during cleanup

## Testing
- pnpm lint *(fails: existing lint warnings in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c1f898a883279e2358bd667b774b

## Zusammenfassung von Sourcery

Zentralisierung des Transportmanagements durch die Einführung eines Session-Store-Moduls und die Aktualisierung der öffentlichen MetaMCP-, STDIO-Proxy- und privaten MetaMCP-Router, um Transport-Instanzen über den gemeinsamen Store zu speichern, abzurufen und zu bereinigen.

Neue Funktionen:
- Einen gemeinsamen Session-Transport-Store mit setTransport-, getTransport- und deleteTransport-Helfern hinzufügen

Verbesserungen:
- Öffentliche MetaMCP SSE- und Nachrichtenrouten refaktorisieren, um den gemeinsamen Session-Store zu nutzen und Transports beim Schließen der Verbindung zu bereinigen
- STDIO-Proxy refaktorisieren, um den gemeinsamen Session-Store für SSE- und prozessverwaltete Transports zu nutzen und die Bereinigungslogik zu zentralisieren
- Privaten MetaMCP-Router aktualisieren, um den gemeinsamen Session-Store für HTTP- und SSE-Transports zu nutzen und sich in Bereinigungsereignisse einzuhaken

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize transport management by introducing a session-store module and updating public MetaMCP, STDIO proxy, and private MetaMCP routers to store, retrieve, and clean up Transport instances via the shared store

New Features:
- Add a shared session transport store with setTransport, getTransport, and deleteTransport helpers

Enhancements:
- Refactor public MetaMCP SSE and message routes to use the shared session store and cleanup transports on connection close
- Refactor STDIO proxy to leverage the shared session store for SSE and process-managed transports and centralize cleanup logic
- Update private MetaMCP router to use the shared session store for HTTP and SSE transports and hook into cleanup events

</details>