### PR TITLE
Add MetaMCP cleanup shutdown hook

### DIFF
--- a/apps/backend/src/routers/mcp-proxy/metamcp.ts
+++ b/apps/backend/src/routers/mcp-proxy/metamcp.ts
@@ -145,6 +145,10 @@ const performTimeBasedCleanup = async () => {
 // Start time-based cleanup timer for MetaMCP
 const cleanupTimer = setInterval(performTimeBasedCleanup, CLEANUP_INTERVAL);
 
+export const stopMetaMcpCleanup = () => {
+  clearInterval(cleanupTimer);
+};
+
 metamcpRouter.get("/:uuid/mcp", async (req, res) => {
   const namespaceUuid = req.params.uuid;
   const apiKey = extractApiKey(req);


### PR DESCRIPTION
## Summary
- export a MetaMCP helper that clears the periodic cleanup timer
- attach the backend server's close and shutdown signals to invoke the MetaMCP cleanup
- ensure graceful shutdown cleans up MetaMCP intervals when the process exits

## Testing
- pnpm lint *(fails: existing lint warnings in unrelated files)*
- pnpm --filter backend exec -- eslint src/index.ts


------
https://chatgpt.com/codex/tasks/task_e_68c8c2088a6c83278be3f2ebee1d6d4a

## Zusammenfassung von Sourcery

Verbesserungen:
- Exportiere den `stopMetaMcpCleanup` Helfer und füge HTTP-Server-'close'- und Prozess-SIGTERM/SIGINT-Handler hinzu, um MetaMCP-Intervalle beim Herunterfahren zu löschen

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Export stopMetaMcpCleanup helper and attach HTTP server 'close' and process SIGTERM/SIGINT handlers to clear MetaMCP intervals on shutdown

</details>